### PR TITLE
Fix Mali GPU shader compilat error

### DIFF
--- a/app/src/main/java/com/ljyh/mei/ui/component/player/component/mesh/ShaderSource.kt
+++ b/app/src/main/java/com/ljyh/mei/ui/component/player/component/mesh/ShaderSource.kt
@@ -2,9 +2,9 @@ package com.ljyh.mei.ui.component.player.component.mesh
 
 object ShaderSource {
 
-    const val MESH_VERTEX_SHADER = """
-#version 300 es
+    const val MESH_VERTEX_SHADER = """#version 300 es
 precision highp float;
+precision highp int;
 
 in vec2 a_pos;
 in vec3 a_color;
@@ -28,9 +28,9 @@ void main() {
 }
 """
 
-    const val MESH_FRAGMENT_SHADER = """
-#version 300 es
+    const val MESH_FRAGMENT_SHADER = """#version 300 es
 precision highp float;
+precision highp int;
 
 in vec3 v_color;
 in vec2 v_uv;
@@ -77,9 +77,9 @@ void main() {
 }
 """
 
-    const val QUAD_VERTEX_SHADER = """
-#version 300 es
+    const val QUAD_VERTEX_SHADER = """#version 300 es
 precision highp float;
+precision highp int;
 
 in vec2 a_pos;
 in vec2 a_texCoord;
@@ -92,9 +92,9 @@ void main() {
 }
 """
 
-    const val QUAD_FRAGMENT_SHADER = """
-#version 300 es
+    const val QUAD_FRAGMENT_SHADER = """#version 300 es
 precision highp float;
+precision highp int;
 
 in vec2 v_texCoord;
 


### PR DESCRIPTION
Fix Mali GPU shader compilat error
#version must be on the first line
修复天玑 / Mali GPU 设备上着色器编译失败的问题
在 Mali GPU 机型上，GLES 报错 P0005: #version must be on the first line in a program
根据 GLSL 规范，#version 必须是 Shader 源码的第一行。Kotlin 代码中 ShaderSource.kt 使用三引号 """ 换行时，生成的字符串开头带有一个 \n。Adreno GPU 容错较高能正常运行，但 Mali GPU 会拒绝编译

将 #version 300 es 紧贴三引号编写（如 """#version 300 es），确保其位于字符串绝对首行